### PR TITLE
Fix GCC warning about stringop-overflow

### DIFF
--- a/src/glow.c
+++ b/src/glow.c
@@ -150,8 +150,8 @@ void render_glow_filter(glow_filter_data_t *data)
 				       : "FilterInnerGlow";
 
 	char shader_id[100] = "";
-	strncat(shader_id, position, strlen(position));
-	strncat(shader_id, fill_type, strlen(fill_type));
+	strcat(shader_id, position);
+	strcat(shader_id, fill_type);
 
 	set_blending_parameters();
 

--- a/src/stroke.c
+++ b/src/stroke.c
@@ -267,8 +267,8 @@ void render_fill_stroke_filter(stroke_filter_data_t *data)
 				       : "Inner";
 
 	char shader_id[100] = "";
-	strncat(shader_id, fill_type, strlen(fill_type));
-	strncat(shader_id, position, strlen(position));
+	strcat(shader_id, fill_type);
+	strcat(shader_id, position);
 
 	set_blending_parameters();
 


### PR DESCRIPTION
When building with GCC, a warning is raised about string operation overflow for the usages of `strncat`. This doesn't happen by default, but when building on Arch Linux system, the `makepkg` default configuration enables certain extra warnings.

After some searching it seems that GCC warns about it because calling `strncat` with the source string length as 3rd argument is essentially the same as calling the simpler `strcat` function.
