### PR TITLE
fix: prevent shader ID buffer overflow issues

### DIFF
--- a/src/glow.c
+++ b/src/glow.c
@@ -171,8 +171,7 @@ void render_glow_filter(glow_filter_data_t *data)
 				       : "FilterInnerGlow";
 
 	char shader_id[100] = "";
-	strncat(shader_id, position, strlen(position));
-	strncat(shader_id, fill_type, strlen(fill_type));
+	snprintf(shader_id, sizeof(shader_id), "%s%s", position, fill_type);
 
 	set_blending_parameters();
 

--- a/src/stroke.c
+++ b/src/stroke.c
@@ -288,8 +288,7 @@ void render_fill_stroke_filter(stroke_filter_data_t *data)
 				       : "Inner";
 
 	char shader_id[100] = "";
-	strncat(shader_id, fill_type, strlen(fill_type));
-	strncat(shader_id, position, strlen(position));
+	snprintf(shader_id, sizeof(shader_id), "%s%s", fill_type, position);
 
 	set_blending_parameters();
 


### PR DESCRIPTION
This pull request replaces the strncat method used to create the sharder ID with snprintf to safely concatenate strings into shader_id, ensuring the buffer size is not exceeded and the resulting string is null-terminated. This prevents potential buffer overflow and improves code safety.
